### PR TITLE
Allow to disable the default mappings

### DIFF
--- a/plugin/gv.vim
+++ b/plugin/gv.vim
@@ -229,7 +229,11 @@ function! s:list(fugitive_repo, log_opts)
   if !exists(':Gbrowse')
     doautocmd User Fugitive
   endif
-  call s:maps()
+
+  if !exists('g:gv_disable_default_mappings')
+    call s:maps()
+  endif
+
   call s:syntax()
   redraw
   echo 'o: open split / O: open tab / gb: Gbrowse / q: quit'


### PR DESCRIPTION
This patch allows to disable the default mappings in case somebody wants
to change it. Just set the variable `let g:gv_disable_default_mappings =
1` in your vimrc and change the mappings to your liking.