### PR TITLE
<nomodeline>

### DIFF
--- a/plugin/gv.vim
+++ b/plugin/gv.vim
@@ -110,7 +110,7 @@ function! s:open(visual, ...)
   nnoremap <silent> <buffer> q :close<cr>
   let bang = a:0 ? '!' : ''
   if exists('#User#GV'.bang)
-    execute 'doautocmd User GV'.bang
+    execute 'doautocmd <nomodeline> User GV'.bang
   endif
   wincmd p
   echo
@@ -238,7 +238,7 @@ function! s:list(fugitive_repo, log_opts)
   setlocal nowrap tabstop=8 cursorline iskeyword+=#
 
   if !exists(':Gbrowse')
-    doautocmd User Fugitive
+    doautocmd <nomodeline> User Fugitive
   endif
   call s:maps()
   call s:syntax()


### PR DESCRIPTION
If a log contains "vim:" then Vim may erroneously regard it as
a modeline, but this is nonsense in the context of GV.

References https://github.com/tpope/vim-fugitive/issues/580