### PR TITLE
Give the log buffer a useful name. Re-use existing buffer.

### DIFF
--- a/plugin/gv.vim
+++ b/plugin/gv.vim
@@ -254,6 +254,11 @@ function! s:list(fugitive_repo, log_opts)
   let default_opts = ['--color=never', '--date=short', '--format=%cd %h%d %s (%an)']
   let git_args = ['log'] + default_opts + a:log_opts
   let git_log_cmd = call(a:fugitive_repo.git_command, git_args, a:fugitive_repo)
+
+  let repo_short_name = fnamemodify(substitute(a:fugitive_repo.dir(), '[\\/]\.git[\\/]\?$', '', ''), ':t')
+  let bufname = repo_short_name.' '.join(a:log_opts)
+  silent exe (bufexists(bufname) ? 'buffer' : 'file') fnameescape(bufname)
+
   call s:fill(git_log_cmd)
   setlocal nowrap tabstop=8 cursorline iskeyword+=#
 


### PR DESCRIPTION
Buffer name looks `<repo> <optional args>`, e.g.:

- `foo --graph` invoked by `:GV`
- `foo HEAD --graph` invoked by `:GV HEAD`

I know @junegunn you mentioned you rarely use tabs, so this probably seems silly, specially since the buffers are not listed. That raises another point: 'nobuflisted' causes `i_CTRL-N` not to complete from the gv.vim buffer(s), unless the user has `complete+=U`. I would suggest not setting `nobuflisted`, specially since the buffers have names with this PR.