### PR TITLE
Fix "GV?" location list path concealment on Windows

### DIFF
--- a/plugin/gv.vim
+++ b/plugin/gv.vim
@@ -306,8 +306,8 @@ function! s:gl(buf, visual)
   nnoremap <buffer> o <cr><c-w><c-w>
   nnoremap <buffer> O :call <sid>gld()<cr>
   nnoremap <buffer> q :tabclose<cr>
-  call matchadd('Conceal', '^fugitive:///.\{-}\.git//')
-  call matchadd('Conceal', '^fugitive:///.\{-}\.git//\x\{7}\zs.\{-}||')
+  call matchadd('Conceal', '^fugitive://.\{-}\.git//')
+  call matchadd('Conceal', '^fugitive://.\{-}\.git//\x\{7}\zs.\{-}||')
   setlocal concealcursor=nv conceallevel=3 nowrap
   let w:quickfix_title = 'o: open / o (in visual): diff / O: open (tab) / q: quit'
 endfunction


### PR DESCRIPTION
Hello. Here is a minor bugfix for GV? command. On Windows fugitive's Gllog command outputs something like 
`fugitive://C:/path/.git//b245582814c476a8242b15c068668bffd42eeb37/main.cpp`
and regexps
`call matchadd('Conceal', '^fugitive:///.\{-}\.git//')`
`call matchadd('Conceal', '^fugitive:///.\{-}\.git//\x\{7}\zs.\{-}||')`
don't match. 