### PR TITLE
Pass filename explicitly

### DIFF
--- a/plugin/gv.vim
+++ b/plugin/gv.vim
@@ -245,7 +245,7 @@ function! s:log_opts(fugitive_repo, bang, visual, line1, line2)
   if a:visual || a:bang
     let current = expand('%')
     call s:check_buffer(a:fugitive_repo, current)
-    return a:visual ? [printf('-L%d,%d:%s', a:line1, a:line2, current)] : ['--follow', current]
+    return a:visual ? [printf('-L%d,%d:%s', a:line1, a:line2, current)] : ['--follow', '--', current]
   endif
   return ['--graph']
 endfunction


### PR DESCRIPTION
When `:GV!` is used, some existing branch names that's similar with the filename can lead errors. Here is how to reproduce the problem:

``` sh
git clone https://github.com/junegunn/gv.vim
cd gv.vim
git checkout -b README.md
vim +GV! README.md
```

Then there will be an error:
```
fatal: ambiguous argument 'README.md': both revision and filename
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```