### PR TITLE
Provide `gq` mapping for "quit"

### DIFF
--- a/plugin/gv.vim
+++ b/plugin/gv.vim
@@ -306,6 +306,7 @@ function! s:gl(buf, visual)
   nnoremap <buffer> o <cr><c-w><c-w>
   nnoremap <buffer> O :call <sid>gld()<cr>
   nnoremap <buffer> q :tabclose<cr>
+  nnoremap <buffer> gq :tabclose<cr>
   call matchadd('Conceal', '^fugitive://.\{-}\.git//')
   call matchadd('Conceal', '^fugitive://.\{-}\.git//\x\{7}\zs.\{-}||')
   setlocal concealcursor=nv conceallevel=3 nowrap


### PR DESCRIPTION
vim-fugitive now uses `gq` instead of `q` for "quit" behavior:
tpope/vim-fugitive@a510b3a

This is a better convention because macro-recording (builtin `q`) is more useful in readonly/special-purpose buffers than text-formatting (builtin `gq`).

I assume that gv.vim doesn't want to remove the `q` mapping, but providing `gq` at least avoids muscle-memory conflicts.