### PR TITLE
Replace removed fugitive API call (fugitive#detect) with a public API

### DIFF
--- a/plugin/gv.vim
+++ b/plugin/gv.vim
@@ -344,7 +344,7 @@ function! s:gv(bang, visual, line1, line2, args) abort
       let log_opts = extend(gv#shellwords(a:args), s:log_opts(fugitive_repo, a:bang, a:visual, a:line1, a:line2))
       call s:setup(git_dir, fugitive_repo.config('remote.origin.url'))
       call s:list(fugitive_repo, log_opts)
-      call fugitive#detect(@#)
+      call FugitiveDetect(@#)
     endif
   catch
     return s:warn(v:exception)


### PR DESCRIPTION
Since fugitive has removed some APIs such as fugitive#detect,
now GV is emitting error messages. A public API should be used.

Fugitive upstream commit: https://github.com/tpope/vim-fugitive/commit/cd7db1d57cc991b27d9c9ce6552faea3075ada61
Related issues: #69, #70