### PR TITLE
Disable modelines in scratch buffers

### DIFF
--- a/plugin/gv.vim
+++ b/plugin/gv.vim
@@ -212,7 +212,7 @@ function! s:setup(git_dir, git_origin)
 endfunction
 
 function! s:scratch()
-  setlocal buftype=nofile bufhidden=wipe noswapfile
+  setlocal buftype=nofile bufhidden=wipe noswapfile nomodeline
 endfunction
 
 function! s:fill(cmd)


### PR DESCRIPTION
Fix errors when commits contain "vim: ".

Our scratch buffers will never have modelines, so prevent vim from
parsing any of their content as modelines.

I have a snippets repo with commit messages that look like modelines:
"vim: Add if snippet" and they cause :GV to output errors:

    Error detected while processing modelines[2]
    E518: Unknown option: Add