### PR TITLE
Fix error when using lcd, amend commit 11c1ca1.

### DIFF
--- a/plugin/gv.vim
+++ b/plugin/gv.vim
@@ -362,7 +362,7 @@ function! s:gv(bang, visual, line1, line2, args) abort
     return s:warn(v:exception)
   finally
     if getcwd() !=# cwd
-      cd -
+      execute cd '-'
     endif
   endtry
 endfunction


### PR DESCRIPTION
Fix cd command used is not from ```cd``` variable when reverting back the working directory to original path.