### PR TITLE
Refresh git log buffer with `r` 

### DIFF
--- a/plugin/gv.vim
+++ b/plugin/gv.vim
@@ -167,6 +167,7 @@ endfunction
 function! s:maps()
   nnoremap <silent> <buffer> q    :$wincmd w <bar> close<cr>
   nnoremap <silent> <buffer> <nowait> gq :$wincmd w <bar> close<cr>
+  nnoremap <silent> <buffer> r    :call <sid>refresh()<cr>
   nnoremap <silent> <buffer> gb   :call <sid>gbrowse()<cr>
   nnoremap <silent> <buffer> <cr> :call <sid>open(0)<cr>
   nnoremap <silent> <buffer> o    :call <sid>open(0)<cr>
@@ -247,13 +248,13 @@ endfunction
 function! s:list(fugitive_repo, log_opts)
   let default_opts = ['--color=never', '--date=short', '--format=%cd %h%d %s (%an)']
   let git_args = ['log'] + default_opts + a:log_opts
-  let git_log_cmd = call(a:fugitive_repo.git_command, git_args, a:fugitive_repo)
+  let b:git_log_cmd = call(a:fugitive_repo.git_command, git_args, a:fugitive_repo)
 
   let repo_short_name = fnamemodify(substitute(a:fugitive_repo.dir(), '[\\/]\.git[\\/]\?$', '', ''), ':t')
   let bufname = repo_short_name.' '.join(a:log_opts)
   silent exe (bufexists(bufname) ? 'buffer' : 'file') fnameescape(bufname)
 
-  call s:fill(git_log_cmd)
+  call s:fill(b:git_log_cmd)
   setlocal nowrap tabstop=8 cursorline iskeyword+=#
 
   if !exists(':GBrowse')
@@ -262,7 +263,15 @@ function! s:list(fugitive_repo, log_opts)
   call s:maps()
   call s:syntax()
   redraw
-  echo 'o: open split / O: open tab / gb: GBrowse / q: quit'
+  echo 'o: open split / O: open tab / gb: GBrowse / r: refresh / q: quit'
+endfunction
+
+function! s:refresh()
+  " refresh current GV buffer
+  setlocal modifiable
+  normal! gg"_dG
+  setlocal nomodifiable
+  call s:fill(b:git_log_cmd)
 endfunction
 
 function! s:trim(arg)

--- a/plugin/gv.vim
+++ b/plugin/gv.vim
@@ -246,13 +246,13 @@ function! s:log_opts(fugitive_repo, bang, visual, line1, line2)
 endfunction
 
 function! s:list(fugitive_repo, log_opts)
-  let default_opts = ['--color=never', '--date=short', '--format=%cd %h%d %s (%an)']
-  let git_args = ['log'] + default_opts + a:log_opts
-  let b:git_log_cmd = call(a:fugitive_repo.git_command, git_args, a:fugitive_repo)
-
   let repo_short_name = fnamemodify(substitute(a:fugitive_repo.dir(), '[\\/]\.git[\\/]\?$', '', ''), ':t')
   let bufname = repo_short_name.' '.join(a:log_opts)
   silent exe (bufexists(bufname) ? 'buffer' : 'file') fnameescape(bufname)
+
+  let default_opts = ['--color=never', '--date=short', '--format=%cd %h%d %s (%an)']
+  let git_args = ['log'] + default_opts + a:log_opts
+  let b:git_log_cmd = call(a:fugitive_repo.git_command, git_args, a:fugitive_repo)
 
   call s:fill(b:git_log_cmd)
   setlocal nowrap tabstop=8 cursorline iskeyword+=#


### PR DESCRIPTION
In a GV buffer, hit `r` to refresh the git log print out.

This achieves the same goal as (#53), but uses a different implementation.

In particular:
* Hitting `r` will call `s:refresh()`. 
* `s:refresh()` first empties the current GV buffer, then `s:fill()`s it with the same `git_log_cmd`
* `git_log_cmd` is changed to be a buffer-local variable (`b:`), so that one can reuse the same git log command for the same buffer.

The third point enables `s:refresh()` to be used with multiple GV instances.
In addition, other split windows (such as the diff window) are also preserved in the current tab.


