### PR TITLE
Use fugitive#LogComplete for -complete

### DIFF
--- a/plugin/gv.vim
+++ b/plugin/gv.vim
@@ -368,8 +368,4 @@ function! s:gv(bang, visual, line1, line2, args) abort
   endtry
 endfunction
 
-function! s:gvcomplete(a, l, p) abort
-  return fugitive#repo().superglob(a:a)
-endfunction
-
-command! -bang -nargs=* -range=0 -complete=customlist,s:gvcomplete GV call s:gv(<bang>0, <count>, <line1>, <line2>, <q-args>)
+command! -bang -nargs=* -range=0 -complete=customlist,fugitive#LogComplete GV call s:gv(<bang>0, <count>, <line1>, <line2>, <q-args>)


### PR DESCRIPTION
`fugitive#LogComplete` is the context-sensitive `customlist` function used for `:G log`.