### PR TITLE
Call 0Gllog in normal mode

### DIFF
--- a/plugin/gv.vim
+++ b/plugin/gv.vim
@@ -263,7 +263,7 @@ function! s:gl(buf, visual)
     return
   endif
   tab split
-  silent execute a:visual ? "'<,'>" : "" 'Gllog'
+  silent execute a:visual ? "'<,'>Gllog" : '0Gllog'
   call setloclist(0, insert(getloclist(0), {'bufnr': a:buf}, 0))
   noautocmd b #
   lopen


### PR DESCRIPTION
Call 0Gllog to "fill the location list with the revisions of the current file" in normal mode.

:GV? currently does not work as described in the README - in order to "fill the location list with the revisions of the current file" in normal mode, we must use 0Gllog, not Gllog.