### PR TITLE
Fix no previous directory issue

### DIFF
--- a/plugin/gv.vim
+++ b/plugin/gv.vim
@@ -321,7 +321,7 @@ function! s:gv(bang, visual, line1, line2, args) abort
     return s:warn(v:exception)
   finally
     if getcwd() !=# cwd
-      cd -
+      execute cd escape(cwd, ' ')
     endif
   endtry
 endfunction


### PR DESCRIPTION
Fixes #103 

It's a bit unclear why this issue started happening recently, perhaps some mainline vim changes caused the breakage? Either way, I feel like depending on `cd -` feels a bit fragile since we already have the original working directory stored in a variable, so I tweaked the `finally` to return us to the right place