### PR TITLE
Fix windows split: do not open a new window even if gv window was moved

### DIFF
--- a/plugin/gv.vim
+++ b/plugin/gv.vim
@@ -84,11 +84,19 @@ endfunction
 function! s:split(tab)
   if a:tab
     call s:tabnew()
-  elseif getwinvar(winnr('$'), 'gv')
-    $wincmd w
-    enew
   else
-    vertical botright new
+    let l:gv_win = 0
+    for l:win_number in range(1, winnr('$'))
+      if getwinvar(l:win_number, 'gv')
+        let l:gv_win = l:win_number
+      endif
+    endfor
+    if l:gv_win
+      call win_gotoid(win_getid(l:gv_win))
+    else
+      vertical botright new
+    end
+    enew
   endif
   let w:gv = 1
 endfunction

--- a/plugin/gv.vim
+++ b/plugin/gv.vim
@@ -85,18 +85,13 @@ function! s:split(tab)
   if a:tab
     call s:tabnew()
   else
-    let l:gv_win = 0
-    for l:win_number in range(1, winnr('$'))
-      if getwinvar(l:win_number, 'gv')
-        let l:gv_win = l:win_number
-      endif
-    endfor
-    if l:gv_win
-      call win_gotoid(win_getid(l:gv_win))
+    let w = get(filter(range(1, winnr('$')), 'getwinvar(v:val, "gv")'), 0)
+    if w
+      execute w.'wincmd w'
+      enew
     else
       vertical botright new
-    end
-    enew
+    endif
   endif
   let w:gv = 1
 endfunction


### PR DESCRIPTION
Problem: When reusing the splitted window to show a commit (that has
`w:gv` = 1), only the rightmost window (winnr = '$') is considered.
This results in a weird behavior that, if the window is moved to top
or left, another window will be opened in split.

Solution: Search all the windows in the current webpage to find the
target window with `w:gv = 1`.
